### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Functions
+ * EA Genesis Child.
  *
  * @package      EA_Genesis_Child
  * @since        1.0.0
@@ -8,72 +8,79 @@
  * @author       Bill Erickson <bill@billerickson.net>
  * @author       Jared Atchison <jared@jaredatchison.com>
  * @copyright    Copyright (c) 2013, Bill Erickson & Jared Atchison
- * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @license      GPL-2.0+
  *
  */
 
+add_action( 'genesis_setup', 'ea_child_theme_setup', 15 );
 /**
- * Theme Setup
+ * Theme setup - attach all of the site-wide functions to the correct hooks and filters.
+ *
+ * All the functions themselves are defined below this setup function.
+ *
  * @since 1.0.0
- *
- * This setup function attaches all of the site-wide functions 
- * to the correct hooks and filters. All the functions themselves
- * are defined below this setup function.
- *
  */
-
-add_action('genesis_setup','ea_child_theme_setup', 15);
 function ea_child_theme_setup() {
-	
+
 	define( 'CHILD_THEME_VERSION', filemtime( get_stylesheet_directory() . '/style.css' ) );
-	
+
 	// Remove Unused Genesis Features
 	include_once( get_stylesheet_directory() . '/inc/functions/genesis-cleanup.php' );
-	
+
 	// Editor Styles
 	add_editor_style( 'css/editor-style.css' );
-	
+
 	// Theme Supports
 	add_theme_support( 'genesis-html5' );
 	add_theme_support( 'genesis-responsive-viewport' );
-	add_theme_support( 'genesis-structural-wraps', array( 'header', 'nav', 'subnav', 'inner', 'footer-widgets', 'footer' ) );
 	add_theme_support( 'genesis-footer-widgets', 3 );
-	add_theme_support( 'genesis-menus', array( 
-		'primary' => 'Primary Navigation Menu',
-		'secondary' => 'Secondary Navigation Menu' 
-	) );
+	add_theme_support( 'genesis-structural-wraps', array( 'header', 'menu-primary', 'menu-secondary', 'site-inner', 'footer-widgets', 'footer' ) );
+	// add_theme_support(
+	// 	'genesis-menus',
+	// 	array(
+	// 		'primary'   => __( 'Primary Navigation Menu', 'ea_genesis_child' ),
+	// 		'secondary' => __( 'Secondary Navigation Menu', 'ea_genesis_child' ),
+	// 	)
+	// );
 
 	// Image Sizes
-	// add_image_size( 'be_featured', 400, 100, true );
+	// add_image_size( 'ea_featured', 400, 100, true );
 
 	// Sidebars
-	//genesis_register_sidebar( array( 'name' => 'Blog Sidebar', 'id' => 'blog-sidebar' ) );
-		
+	// genesis_register_sidebar(
+	// 	array(
+	// 		'id'          => 'blog-sidebar',
+	// 		'name'        => __( 'Blog Sidebar', 'ea_genesis_child' ),
+	// 		'description' => __( '', 'ea_genesis_child' ),
+	// 	)
+	// );
+
 	// Don't update theme
 	add_filter( 'http_request_args', 'ea_dont_update_theme', 5, 2 );
-		
-	// ** Frontend **		
-	
+
+	// ** Frontend **
+
 	// Remove Edit link
 	add_filter( 'genesis_edit_post_link', '__return_false' );
-	
+
 }
 
 // ** Backend Functions ** //
 
 /**
- * Don't Update Theme
- * @since 1.0.0
+ * Don't Update Theme.
  *
- * If there is a theme in the repo with the same name, 
- * this prevents WP from prompting an update.
+ * If there is a theme in the repo with the same name, this prevents WP from prompting an update.
+ *
+ * @since 1.0.0
  *
  * @author Mark Jaquith
  * @link http://markjaquith.wordpress.com/2009/12/14/excluding-your-plugin-or-theme-from-update-checks/
  *
- * @param array $r, request arguments
- * @param string $url, request url
- * @return array request arguments
+ * @param  array  $r    Existing request arguments.
+ * @param  string $url, Request URL.
+ *
+ * @return array Amended request arguments.
  */
 
 function ea_dont_update_theme( $r, $url ) {


### PR DESCRIPTION
- Tidies up and fixes some documentation.
- Fixes whitespace coding standards
- Fixes structural wrap list for HTML5 mode
- Comments out genesis-menus support, as this is exactly the default anyway.
- Adds i18n support to strings, with default `ea_genesis_child` text domain. Great for those that need it (selling themes), no harm for those that don't (custom theme for single client).
- Adds description key to widget area registration array - improves UI by reminding users what sort of thing should go in a particular widget area.
- 
