### PR TITLE
Update genesis-cleanup.php

### DIFF
--- a/inc/functions/genesis-cleanup.php
+++ b/inc/functions/genesis-cleanup.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Genesis Cleanup
+ * EA Genesis Child.
  *
  * @package      EA_Genesis_Child
  * @since        1.0.0
@@ -8,19 +8,19 @@
  * @author       Bill Erickson <bill@billerickson.net>
  * @author       Jared Atchison <jared@jaredatchison.com>
  * @copyright    Copyright (c) 2013, Bill Erickson & Jared Atchison
- * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @license      GPL-2.0+
  *
  */
- 
-// Remove Unused Page Layouts
+
+// Remove unused page layouts
 genesis_unregister_layout( 'content-sidebar-sidebar' );
 genesis_unregister_layout( 'sidebar-sidebar-content' );
 genesis_unregister_layout( 'sidebar-content-sidebar' );
-	
-// Remove Unused Sidebar
+
+// Remove unused secondary sidebar
 unregister_sidebar( 'sidebar-alt' );
 
-// Remove Unused User Settings
+// Remove unused user settings
 remove_action( 'show_user_profile', 'genesis_user_options_fields' );
 remove_action( 'edit_user_profile', 'genesis_user_options_fields' );
 remove_action( 'show_user_profile', 'genesis_user_archive_fields' );
@@ -30,29 +30,37 @@ remove_action( 'edit_user_profile', 'genesis_user_seo_fields' );
 remove_action( 'show_user_profile', 'genesis_user_layout_fields' );
 remove_action( 'edit_user_profile', 'genesis_user_layout_fields' );
 
+remove_action( 'admin_menu', 'genesis_add_inpost_seo_box' );
+add_action( 'admin_menu', 'ea_add_inpost_seo_box' );
 /**
- * Reposition Genesis SEO Metabox
- * from /lib/admin/inpost-metaboxes.php, version 2.0
+ * Re-prioritise Genesis SEO metabox from high to default.
+ *
+ * Copied and amended from /lib/admin/inpost-metaboxes.php, version 2.0.0.
+ *
+ * @since 1.0.0
  */
-function be_add_inpost_seo_box() {
+function ea_add_inpost_seo_box() {
 
 	if ( genesis_detect_seo_plugins() )
 		return;
-		
+
 	foreach ( (array) get_post_types( array( 'public' => true ) ) as $type ) {
 		if ( post_type_supports( $type, 'genesis-seo' ) )
 			add_meta_box( 'genesis_inpost_seo_box', __( 'Theme SEO Settings', 'genesis' ), 'genesis_inpost_seo_box', $type, 'normal', 'default' );
 	}
 
 }
-remove_action( 'admin_menu', 'genesis_add_inpost_seo_box' );
-add_action( 'admin_menu', 'be_add_inpost_seo_box' );
 
+remove_action( 'admin_menu', 'genesis_add_inpost_layout_box' );
+add_action( 'admin_menu', 'ea_add_inpost_layout_box' );
 /**
- * Reposition Layout Metabox
- * from /lib/admin/inpost-metaboxes.php, version 2.0
+ * Re-prioritise layout metabox from high to default.
+ *
+ * Copied and amended from /lib/admin/inpost-metaboxes.php, version 2.0.0.
+ *
+ * @since 1.0.0
  */
-function be_add_inpost_layout_box() {
+function ea_add_inpost_layout_box() {
 
 	if ( ! current_theme_supports( 'genesis-inpost-layouts' ) )
 		return;
@@ -63,31 +71,27 @@ function be_add_inpost_layout_box() {
 	}
 
 }
-remove_action( 'admin_menu', 'genesis_add_inpost_layout_box' );
-add_action( 'admin_menu', 'be_add_inpost_layout_box' );
 
-
-/** 
- * Remove Genesis widgets
+add_action( 'widgets_init', 'ea_remove_genesis_widgets', 20 );
+/**
+ * Remove Genesis widgets.
  *
  * @since 1.0.0
  */
-function be_remove_genesis_widgets() {
-    unregister_widget( 'Genesis_eNews_Updates'          );
-    unregister_widget( 'Genesis_Featured_Page'          );
-    unregister_widget( 'Genesis_Featured_Post'          );
-    unregister_widget( 'Genesis_Latest_Tweets_Widget'   );
-    unregister_widget( 'Genesis_User_Profile_Widget'    );
+function ea_remove_genesis_widgets() {
+    unregister_widget( 'Genesis_Featured_Page' );
+    unregister_widget( 'Genesis_Featured_Post' );
+    unregister_widget( 'Genesis_User_Profile_Widget' );
 }
-add_action( 'widgets_init', 'be_remove_genesis_widgets', 20 );
-	
+
+add_action( 'genesis_theme_settings_metaboxes', 'ea_remove_genesis_metaboxes' );
 /**
- * Remove Genesis Theme Settings Metaboxes
+ * Remove Genesis theme settings metaboxes.
  *
  * @since 1.0.0
  * @param string $_genesis_theme_settings_pagehook
  */
-function be_remove_genesis_metaboxes( $_genesis_theme_settings_pagehook ) {
+function ea_remove_genesis_metaboxes( $_genesis_theme_settings_pagehook ) {
 	//remove_meta_box( 'genesis-theme-settings-feeds',      $_genesis_theme_settings_pagehook, 'main' );
 	//remove_meta_box( 'genesis-theme-settings-header',     $_genesis_theme_settings_pagehook, 'main' );
 	remove_meta_box( 'genesis-theme-settings-nav',        $_genesis_theme_settings_pagehook, 'main' );
@@ -97,4 +101,3 @@ function be_remove_genesis_metaboxes( $_genesis_theme_settings_pagehook ) {
 	remove_meta_box( 'genesis-theme-settings-blogpage',   $_genesis_theme_settings_pagehook, 'main' );
 	//remove_meta_box( 'genesis-theme-settings-scripts',    $_genesis_theme_settings_pagehook, 'main' );
 }
-add_action( 'genesis_theme_settings_metaboxes', 'be_remove_genesis_metaboxes' );


### PR DESCRIPTION
- Documentation improvements.
- Change `be` to `ea` in several places.
- Move `add_action()` and `remove_action()` calls to above documentation, as per Genesis.
- Remove references to non-existent Genesis widgets.
