### PR TITLE
Clarify why header-right is being unregistered

### DIFF
--- a/inc/genesis-changes.php
+++ b/inc/genesis-changes.php
@@ -22,6 +22,8 @@ genesis_unregister_layout( 'sidebar-content-sidebar' );
 
 // Remove unused secondary sidebar
 unregister_sidebar( 'sidebar-alt' );
+
+// Remove header-right widget area if genesis-header-nav plugin is active
 if( class_exists( 'Genesis_Header_Nav' ) )
 	unregister_sidebar( 'header-right' );
 


### PR DESCRIPTION
I missed Bill's commit a few months ago that added the functionality to unregister header-right. When I installed Garys plugin, I had no idea why it vanished.  I just wanted to make it a little bit more obvious in this file what was going on, by adding a comment for it, since this was previously stuck under the "Remove unused secondary sidebar" comment
